### PR TITLE
buildroot use https

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -16,12 +16,6 @@ jobs:
     - name: Download Source
       uses: actions/checkout@v4.2.2
 
-    - name: Install SSH Key
-      uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-      with:
-        ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-        ssh-host: github.com
-
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/build-aar.yml
+++ b/.github/workflows/build-aar.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Install SSH Key
-      uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-      with:
-        ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-        ssh-host: github.com
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
-      - name: Install SSH Key
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-        with:
-          ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-          ssh-host: github.com
       - name: Bundle Install
         run: |-
           SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install --path .bundle
@@ -37,11 +32,6 @@ jobs:
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
-      - name: Install SSH Key
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-        with:
-          ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-          ssh-host: github.com
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
@@ -63,11 +53,6 @@ jobs:
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
-      - name: Install SSH Key
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-        with:
-          ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-          ssh-host: github.com
       - name: Install deps
         run: |
           source tools/envsetup.sh

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
-      - name: Install SSH Key
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
-        with:
-          ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
-          ssh-host: github.com
       - name: Bundle Install
         run: |-
           SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install --path .bundle

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ system = platform.system().lower()
 deps = {
     "build": {
         "type": "git",
-        "url": "git@github.com:lynx-family/buildroot.git",
+        "url": "https://github.com/lynx-family/buildroot.git",
         "commit": "b74a2ad3759ed710e67426eb4ce8e559405ed63f",
         "ignore_in_git": True,
         "condition": system in ["linux", "darwin", "windows"],

--- a/PrimJS.podspec
+++ b/PrimJS.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.license = "MIT"
   s.author = { "pandazyp" => "2823543594@qq.com" }
 
-  s.source = { :git => "git@github.com:lynx-family/primjs.git", :tag => s.version.to_s }
+  s.source = { :git => "https://github.com/lynx-family/primjs.git", :tag => s.version.to_s }
 
   s.compiler_flags = "-Wall", "-Wno-shorten-64-to-32", "-Os"
   s.ios.deployment_target = "9.0"


### PR DESCRIPTION
Using https can avoid the following errors in ci

```
2025-03-05 05:59:24 fv-az1390-389 root[2627] ERROR running command git fetch --force --progress --update-head-ok -- git@github.com:lynx-family/buildroot.git +refs/heads/*:refs/remotes/origin/* in /home/runner/.habitat_cache/git/buildroot.git/95ee6ed180392706ece98afd1d1e087a, original output:
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

```