### PR TITLE
[Infra] add ci job to run custom image container

### DIFF
--- a/.github/workflows/test-harmony.yml
+++ b/.github/workflows/test-harmony.yml
@@ -1,0 +1,31 @@
+name: ci-test-harmony
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test-custom-container:
+    runs-on: lynx-custom-dind
+    container: 
+      image: ghcr.io/lynx-family/harmony:5.0.9.310
+      options: --cap-add=NET_ADMIN
+      credentials:
+        username: lynx-family
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set MTU
+        run: |
+          apt install --no-install-recommends -y iproute2
+          ip link set dev eth0 mtu 1450
+          echo "MTU set successfully"
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - name: debug
+        shell: bash
+        run: |
+          echo 'This is in custom container'


### PR DESCRIPTION
Add a CI task that can execute tasks in a container of the image specified by the user.