### PR TITLE
[Infra]Add missing standard-library headers.

### DIFF
--- a/src/gc/thread_pool.h
+++ b/src/gc/thread_pool.h
@@ -22,6 +22,7 @@
 
 #ifndef _WIN32
 #include <pthread.h>
+#include <unistd.h>
 #endif
 
 #include <atomic>
@@ -29,6 +30,7 @@
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <string>
 
 class ByteTask {
  public:

--- a/src/napi/env/napi_runtime.cc
+++ b/src/napi/env/napi_runtime.cc
@@ -14,6 +14,7 @@
 #include <pthread.h>
 #endif
 
+#include <atomic>
 #include <cassert>
 #include <cstdlib>
 #include <future>

--- a/src/napi/napi.cc
+++ b/src/napi/napi.cc
@@ -10,6 +10,8 @@
 // LICENSE file in the root directory of this source tree.
 #include "napi.h"
 
+#include <cstdlib>
+
 ////////////////////////////////////////////////////////////////////////////////
 // N-API C++ Wrapper Classes
 //


### PR DESCRIPTION
Summary:
Missing standard-library headers cause “symbol not declared” errors under certain toolchains.

issue:m-6789688543
AutoSubmit:true