### PR TITLE
[BugFix] Always enable GC under ENABLE_COMPATIBLE_MM

### DIFF
--- a/src/interpreter/quickjs/source/quickjs.cc
+++ b/src/interpreter/quickjs/source/quickjs.cc
@@ -949,11 +949,7 @@ int init_bigint_name(LEPUSRuntime *rt) {
 
 bool gc_enabled() {
 #ifdef ENABLE_COMPATIBLE_MM
-#if defined(ENABLE_TRACING_GC)
   return true;
-#else
-  return GC_ENABLE & settingsFlag;
-#endif
 #else
   return false;
 #endif


### PR DESCRIPTION
Remove the ENABLE_TRACING_GC / settingsFlag conditional in gc_enabled() so GC is unconditionally enabled when ENABLE_COMPATIBLE_MM is defined.