### PR TITLE
[BugFix] Keep instrumentation opcodes out of the bytecode version

### DIFF
--- a/src/interpreter/quickjs/source/quickjs.cc
+++ b/src/interpreter/quickjs/source/quickjs.cc
@@ -31944,7 +31944,16 @@ fail:
  */
 uint64_t LEPUS_GetPrimjsVersion() {
   constexpr uint64_t unexpected_cnt = 16;
-  uint64_t op_num = OP_COUNT + unexpected_cnt;
+  // Opcodes that only instrumentation emits (currently OP_inc_coverage) can
+  // never reach a serialized function, so they must not move the bytecode
+  // version: bumping it makes every newly built bundle unreadable by every
+  // already shipped runtime, for a capability the bundle does not use.
+  // Raise this together with any new instrumentation-only opcode.
+  constexpr uint64_t instrumentation_op_cnt = 1;
+  static_assert(OP_COUNT - instrumentation_op_cnt == OP_inc_coverage,
+                "instrumentation-only opcodes must stay last in the opcode "
+                "list, and instrumentation_op_cnt must count all of them");
+  uint64_t op_num = (OP_COUNT - instrumentation_op_cnt) + unexpected_cnt;
   uint64_t atom_num = JS_ATOM_END - 1;
   uint64_t primjs_version = op_num + atom_num;
   primjs_version |= VERSION_PLACEHOLDER;


### PR DESCRIPTION
## Problem

`LEPUS_GetPrimjsVersion()` derives the serialized bytecode version from `OP_COUNT`, so **adding any opcode raises it**:

```cpp
uint64_t op_num = OP_COUNT + unexpected_cnt;
uint64_t atom_num = JS_ATOM_END - 1;
uint64_t primjs_version = op_num + atom_num;
```

`JS_CheckBytecodeVersion()` rejects a binary whose version is higher than the runtime's:

```cpp
return binVersion > nowVersion;   // -> "the binary version is higher than runtime"
```

Together this means a new opcode makes every subsequently built bundle unloadable by every already shipped runtime — even when the bundle cannot possibly reference that opcode.

`OP_inc_coverage` is such an opcode. It is emitted only under coverage instrumentation (`LEPUS_Eval_WITH_COVERAGE`) and never reaches a serialized function, but adding it moved the version from 460 to 461.

## Impact

`@lynx-js/tasm` 0.0.51 picked up that PrimJS change. Encoding the same input with 0.0.49 and 0.0.52 produces output that is **byte-identical apart from this single version field** — yet the 0.0.52 output no longer loads on Lynx 3.6, which fails during decode:

```
lynx_binary_base_template_reader.cc(122)] App Bundle's engine version: 3.2, lynx sdk version:3.6, min supported lynx version: 1.0
quick_context.cc(885)] QuickContext deserialize error main-thread.js exception: InternalError: the binary version is higher than runtime
binary_reader.cc(67)] Context construct failed, Function:Decode, Line:48
lynx_error.cc(75)] LynxError occurs error_code:10204 error_message:Decode error: Context construct failed
template_assembler.cc(994)] Decoding template failed
```

The bundle declares `engineVersion: "3.2"`, which is documented as the minimum Lynx Engine version it runs on, so this silently breaks a supported configuration and the page just stays blank.

## Fix

Count only the opcodes a saved function can reference. A `static_assert` pins the assumption that instrumentation-only opcodes stay last in the opcode list, so the constant cannot silently drift.

## Verification

Built `@lynx-js/tasm` from this tree and encoded the same fixtures with and without the patch:

- with the patch the version returns to 460 and the output is **byte-identical to the published `@lynx-js/tasm` 0.0.49**
- against the unpatched build the output differs by **exactly one byte**, the version field

End to end on a physical device (Pixel 4 XL, `LynxExplorer-noasan-release.apk` 3.6.0 from the lynx 3.6.0 release), running the lynx-stack `kitten-lynx` suite:

| bundle built with | version | result |
| --- | --- | --- |
| tasm 0.0.49 | 460 | 5 passed |
| tasm 0.0.52 | 461 | fails to decode, log above |
| tasm 0.0.52 + this patch | 460 | 5 passed |